### PR TITLE
Live Link for Homepage

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,7 @@
 +++
 showtime_date = "12/02/2021"
 showtime_place = "REMOTE"
-is_live = "false"
+is_live = "true"
 zoom_link = "https://htw-berlin.zoom.us/j/97320821203"
 +++
 


### PR DESCRIPTION
Switched homepage to live content

@bkleinen Dieser Pull Request kann heute morgen dann einfach gemerged werden, um das Live-Announcement mit Zoom-Link auf der Homepage anzuzeigen